### PR TITLE
Enable the Windows VMs to deploy in Spoke 2 & Reduce cost of Linux VM

### DIFF
--- a/solutions/azure-hub-spoke/azuredeploy.json
+++ b/solutions/azure-hub-spoke/azuredeploy.json
@@ -412,7 +412,7 @@
             "apiVersion": "2019-10-01",
             "name": "windows-vm",
             "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'virtual-network-spoke-one')]",
+                "[resourceId('Microsoft.Resources/deployments', 'virtual-network-spoke-two')]",
                 "[resourceId('Microsoft.Resources/deployments', 'log-analytics')]"
             ],
             "properties": {
@@ -432,10 +432,10 @@
                         "value": "[parameters('windowsVMCount')]"
                     },
                     "virtualNetworkName": {
-                        "value": "[reference('virtual-network-spoke-one').outputs.virtualNetworkName.value]"
+                        "value": "[reference('virtual-network-spoke-two').outputs.virtualNetworkName.value]"
                     },
                     "subnetName": {
-                        "value": "[reference('virtual-network-spoke-one').outputs.subnetName.value]"
+                        "value": "[reference('virtual-network-spoke-two').outputs.subnetName.value]"
                     },
                     "location": {
                         "value": "[parameters('location')]"

--- a/solutions/azure-hub-spoke/nestedtemplates/azuredeploy-linux-vm.json
+++ b/solutions/azure-hub-spoke/nestedtemplates/azuredeploy-linux-vm.json
@@ -19,7 +19,7 @@
 		},
 		"vmSize": {
 			"type": "string",
-			"defaultValue": "Standard_A1_v2"
+			"defaultValue": "Standard_B1ls"
 		},
 		"location": {
 			"type": "string"


### PR DESCRIPTION
At the moment the Windows VMs and Linux VMs both are getting deployed in VNET Spoke 1, This doesn't allow to test connectivity across Spokes. 

So, Moving the Windows VMs to Spoke 2 so that connectivity 

Also Reducing costs of Linux VM for cost perspective during POC to Standard_b1ls (recently introduced)

thanks