### PR TITLE
(AzureCXP) fix sku for log analytics workspace

### DIFF
--- a/OperationalExcellence/azure-function-powershell/nestedtemplates/azuredeploy-log-analytics.json
+++ b/OperationalExcellence/azure-function-powershell/nestedtemplates/azuredeploy-log-analytics.json
@@ -23,7 +23,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 },
                 "features": {
                     "searchVersion": 1

--- a/solutions/azure-automation-state-configuration/azuredeploy.json
+++ b/solutions/azure-automation-state-configuration/azuredeploy.json
@@ -85,7 +85,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 },
                 "features": {
                     "searchVersion": 1

--- a/solutions/azure-hub-spoke/azuredeploy.json
+++ b/solutions/azure-hub-spoke/azuredeploy.json
@@ -127,7 +127,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 },
                 "features": {
                     "searchVersion": 1

--- a/solutions/basic-web-app/azuredeploy.json
+++ b/solutions/basic-web-app/azuredeploy.json
@@ -21,7 +21,7 @@
             "type": "object",
             "defaultValue": {
                 "name": "[concat('la', '-', uniqueString(subscription().subscriptionId, resourceGroup().id))]",
-                "skuName": "free"
+                "skuName": "PerGB2018"
             },
             "metadata": {
                 "description": "Deployment settings for the Log Analytics workspace."

--- a/solutions/ha-nva/azuredeploy.json
+++ b/solutions/ha-nva/azuredeploy.json
@@ -252,7 +252,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 },
                 "features": {
                     "searchVersion": 1

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
@@ -113,7 +113,7 @@
             "location": "[parameters('location')]",
             "properties": {
                 "sku": {
-                    "name": "Free"
+                    "name": "PerGB2018"
                 },
                 "features": {
                     "searchVersion": 1


### PR DESCRIPTION
Fix the SKU used for Log Analytics Workspaces that still use `Free` which is the legacy pricing tier and the new Pay-As-You-Go Tier is `PerGB2018`.

Resolves MicrosoftDocs/architecture-center#3069, MicrosoftDocs/architecture-center#3087, #171