### PR TITLE
AVMN Deployment Script - Move from REST to Azure PowerShell

### DIFF
--- a/solutions/azure-hub-spoke-connected-group/bicep/modules/avnmDeploymentScript.bicep
+++ b/solutions/azure-hub-spoke-connected-group/bicep/modules/avnmDeploymentScript.bicep
@@ -25,108 +25,50 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
     azPowerShellVersion: '8.3'
     retentionInterval: 'PT1H'
     timeout: 'PT1H'
-    arguments: '-uri "${environment().resourceManager}subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.Network/networkManagers/${networkManagerName}/commit?api-version=2022-05-01" -location ${location} -configIds ${configurationIds} -subscriptionId ${subscription().subscriptionId} -resourceManagerURL ${environment().resourceManager} -configType ${configType}'
+    arguments: '-networkManagerName "${networkManagerName}" -targetLocations ${location} -configIds ${configurationIds} -subscriptionId ${subscription().subscriptionId} -configType ${configType} -resourceGroupName ${resourceGroup().name}'
     scriptContent: '''
     param (
-      $resourceGroup,
-      $subscriptionId,
-      $networkManagerName,
-      $resourceManagerURL,
-      $configIds,
-      $location,
-      $configType,
-      [string]$uri
+      # AVNM subscription id
+      [parameter(mandatory=$true)][string]$subscriptionId,
+
+      # AVNM resource name
+      [parameter(mandatory=$true)][string]$networkManagerName,
+
+      # string with comma-separated list of config ids to deploy. ids must be of the same config type
+      [parameter(mandatory=$true)][string[]]$configIds,
+
+      # string with comma-separated list of deployment target regions
+      [parameter(mandatory=$true)][string[]]$targetLocations,
+
+      # configuration type to deploy. must be either connecticity or securityadmin
+      [parameter(mandatory=$true)][ValidateSet('Connectivity','SecurityAdmin')][string]$configType,
+
+      # AVNM resource group name
+      [parameter(mandatory=$true)][string]$resourceGroupName
     )
-    
-    $DeploymentScriptOutputs = @{}
-    $DeploymentScriptOutputs['text'] = ''
-
+  
     $null = Login-AzAccount -Identity -Subscription $subscriptionId
-
-    $configsJson = ($configIds.split(',') | foreach-object {
-      "`"$_`""
-    }) -join ','
+  
+    [System.Collections.Generic.List[string]]$configIdList = @()  
+    $configIdList.addRange($configIds) 
+    [System.Collections.Generic.List[string]]$targetLocationList = @() # target locations for deployment
+    $targetLocationList.addRange($targetLocations)     
     
-    ### Deploy the connectivityConfiguration by calling the /commit endpoint via REST API ###
-    $body = "{ `
-      `"commitType`": `"$configType`", `
-      `"configurationIds`": [$configsJson], `
-      `"targetLocations`": [`"$location`"] `
-    }"
-
-    $result = Invoke-AzRestMethod -Method POST -URI "$uri" -Payload $body
-
-    $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]Commit status: $($result.statusCode)`n"
-    $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]Commit status: $($result)`n"
-    
-    If ($result.statusCode -ne 202) {
-        throw "Failed to commit connectivity configuration. Status code: '$($result.statusCode)'; Message: '$($result.content)'"
-        exit 1
+    $deployment = @{
+        Name = $networkManagerName
+        ResourceGroupName = $resourceGroupName
+        ConfigurationId = $configIdList
+        TargetLocation = $targetLocationList
+        CommitType = $configType
     }
-    Else {
-      $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-      $timeout = New-TimeSpan -Seconds 300 # five minute timer
-        do {
-          $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]Waiting 1 second for commit to complete...`n"
-            Start-Sleep -Seconds 1
-            $result = Invoke-AzRestMethod -Method GET -Uri $result.Headers.Location
-        }
-        until (($result.StatusCode -eq 204) -or ($timedOut = $stopwatch.elapsed -gt $timeout))
-
-        If ($timedOut) {
-          $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]ERROR: waiting for commit has timed out...`n"
-          throw "Waiting for commit to complete has timed out!"
-          exit 1
-        }
-        Else {
-          $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]Commit completed successfully.`n"
-        }
+  
+    try {
+      Deploy-AzNetworkManagerCommit @deployment -ErrorAction Stop
     }
-
-    ### Now that commit has been successfully submitted, check for successful deployment of the commit ###
-    # check deployment status
-    $body = "{ `
-    `"deploymentTypes`": `"$configType`", `
-    `"regions`": [`"$location`"] `
-    }"
-
-    # update URL from /commit endpoint to /listDeploymentStatus endpoint
-    $uri = $uri.Replace('/commit?', '/listDeploymentStatus?') 
-    $result = Invoke-AzRestMethod -Method POST -URI $uri -Payload $body
-
-    If ($result.statusCode -eq 200) {
-      $content = $result.Content | ConvertFrom-Json -Depth 10
-
-      If ($content.value[0].deploymentStatus -eq 'Deploying') {
-        $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]Deployment status: $($content.value[0].deploymentStatus); waiting for completion...`n"
-
-        While ($content.value[0].deploymentStatus -eq 'Deploying') {
-          $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]Deployment status: $($content.value[0].deploymentStatus); waiting for completion...`n"
-          Start-Sleep -Seconds 10
-          $result = Invoke-AzRestMethod -Method POST -URI $uri -Payload $body
-          $content = $result.Content | ConvertFrom-Json -Depth 10
-        }
-      }
-      If ($content.value[0].deploymentStatus -eq 'Failed') {
-        $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]ERROR: deployment failed - '$($content.value[0].errorMessage)'...`n"
-        throw "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]ERROR: deployment failed - ensure you are in a region that supports AVNM! Error message: '$($content.value[0].errorMessage)'"
-        exit 1
-      }
-      ElseIf ($content.value[0].deploymentStatus -eq 'Deployed') {
-        $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]Deployment completed successfully.`n"
-      }
-      Else {
-        $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]ERROR: Deployment status: '$($content.value[0].deploymentStatus)' is not handled`n"
-        throw "ERROR: Deployment status: '$($content.value[0].deploymentStatus)' is not handled"
-        exit 1
-      }
-    }
-    Else {
-      $DeploymentScriptOutputs['text'] += "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')]ERROR: Failed to get deployment status. Status code: '$($result.statusCode)'`n"
-      throw "ERROR: Failed to get deployment status. Status code: '$($result.statusCode)'"
+    catch {
+      Write-Error "Deployment failed with error: $_"
       exit 1
     }
-
     '''
     }
 }


### PR DESCRIPTION
Reworked the Deployment Script resource in the AVNM Connected Group deployment to use the new `Deploy-AzNetworkManagerCommit` Azure PowerShell command instead of REST API. This will make the script easier to maintain. 

Testing evidence:

Successful deployments: 
![image](https://user-images.githubusercontent.com/25390936/231510914-c948c403-93ef-495f-8f1d-c8906f4bc5e2.png)

Successfully deployed AVNM configurations using new Deployment Script:
![image](https://user-images.githubusercontent.com/25390936/231510838-53956720-22d6-45d1-baae-e8804761b833.png)

