### PR TITLE
Update OS version in secure-hybrid-network

### DIFF
--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
@@ -58,7 +58,7 @@ var peering_name_hub_to_spoke = 'hub-to-spoke'
 var peering_name_spoke_to_hub = 'spoke-to-hub'
 var nicNameWebName = 'nic-web-server'
 var vmNameWebName = 'vm-web-server'
-var windowsOSVersion = '2012-R2-Datacenter'
+var windowsOSVersion = '2016-Datacenter'
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
   name: logAnalyticsWorkspaceName

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
@@ -102,7 +102,7 @@
         "peering-name-spoke-to-hub": "spoke-to-hub",
         "nicNameWeb": "nic-web-server",
         "vmNameWeb": "vm-web-server",
-        "windowsOSVersion": "2012-R2-Datacenter"
+        "windowsOSVersion": "2016-Datacenter"
     },
     "resources": [
         {


### PR DESCRIPTION
I've been trying to run the secure-hybrid-network solution and I keep getting an InvalidTemplateDeployment because one of the nested templates uses 2012-R2-Datacenter as the OS version for one of the resources.

```
{"code": "InvalidTemplateDeployment", "message": "The template deployment 'azuredeploy' is not valid according to the validation procedure. The tracking id is '1be369c8-6371-4409-8423-abac61347168'. See inner errors for details."}

Inner Errors: 
{"code": "InvalidParameter", "target": "imageReference", "message": "The following list of images referenced from the deployment template are not found: Publisher: MicrosoftWindowsServer, Offer: WindowsServer, Sku: 2012-R2-Datacenter, Version: latest. Please refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage for instructions on finding available images."}
```

Changing this variable to 2016-Datacenter in both the .bicep and .json files let me run the deployment successfully.
