### PR TITLE
topic (iac): [secure-hybrid-network] update OS and VM SKU to modern Gen2

### DIFF
--- a/solutions/secure-hybrid-network/README.md
+++ b/solutions/secure-hybrid-network/README.md
@@ -69,7 +69,7 @@ az deployment group create -n firewallDnat -g rg-site-to-site-azure-network-east
 |---|---|---|--|
 | adminUserName | string | The admin user name for the virtual machines. | azureadmin |
 | adminPassword | securestring | The admin password for the virtual machines. | null |
-| vmSize | string | Size of the load-balanced virtual machines. | Standard_A4_v2 |
+| vmSize | string | Size of the load-balanced virtual machines. | Standard_D2s_v3 |
 | configureSitetosite | bool | Condition for configuring a site-to-site VPN connection. | true |
 | hubNetwork | object | Object representing the configuration of the hub network. | name, addressPrefix |
 | spokeNetwork | object | Object representing the configuration of the spoke network. | name, addressPrefix, subnetName, subnetPrefix, subnetNsgName |
@@ -101,7 +101,7 @@ az deployment group create -n firewallDnat -g rg-site-to-site-azure-network-east
 | mocOnpremNetwork | object | Object representing the configuration of the mock on-prem network. | name, addressPrefix, mgmt, subnetPrefix |
 | mocOnpremGateway | object | Object representing the configuration of the VPN gateway. | name, subnetName, subnetPrefix, publicIPAddressName |
 | bastionHost | object | Object representing the configuration of the Bastion host. | name, subnetName, subnetPrefix, publicIPAddressName, nsgName |
-| vmSize | string | Size of the virtual machine. | Standard_A4_v2 |
+| vmSize | string | Size of the virtual machine. | Standard_D2s_v3 |
 | configureSitetosite | bool | Condition for configuring a site-to-site VPN connection. | true |
 | location | string | Location to be used for all resources. | rg location |
 

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
@@ -5,7 +5,7 @@ param adminPassword string
 
 @description('The count of Windows virtual machines to create.')
 param webServerInstanceCount int = 2
-param vmSize string = 'Standard_A4_v2'
+param vmSize string = 'Standard_D2s_v3'
 param configureSitetosite bool = true
 param hubNetwork object = {
   name: 'vnet-hub'
@@ -55,7 +55,7 @@ param location string = resourceGroup().location
 
 var logAnalyticsWorkspaceName = 'la-${uniqueString(subscription().subscriptionId, resourceGroup().id)}'
 var vmssName = 'vmss-web-server'
-var windowsOSVersion = '2016-Datacenter'
+var windowsOSVersion = '2025-datacenter-core-smalldisk-g2'
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   name: logAnalyticsWorkspaceName

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
@@ -18,7 +18,7 @@
         },
         "vmSize": {
             "type": "string",
-            "defaultValue": "Standard_A4_v2"
+            "defaultValue": "Standard_D2s_v3"
         },
         "configureSitetosite": {
             "type": "bool",
@@ -101,7 +101,7 @@
         "vmssName": "vmss-web-server",
         "peering-name-hub-to-spoke": "hub-to-spoke",
         "peering-name-spoke-to-hub": "spoke-to-hub",
-        "windowsOSVersion": "2022-datacenter-g2"
+        "windowsOSVersion": "2025-datacenter-core-smalldisk-g2"
     },
     "resources": [
         {

--- a/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.bicep
@@ -283,6 +283,10 @@ resource windowsVM 'Microsoft.Compute/virtualMachines@2024-11-01' = {
       adminPassword: adminPassword
       windowsConfiguration: {
         enableAutomaticUpdates: true
+        patchSettings: {
+          assessmentMode: 'AutomaticByPlatform'
+          patchMode: 'AutomaticByPlatform'
+        }
       }
     }
     storageProfile: {

--- a/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.bicep
@@ -21,13 +21,13 @@ param bastionHost object = {
   publicIPAddressName: 'pip-bastion'
   nsgName: 'nsg-hub-bastion'
 }
-param vmSize string = 'Standard_A4_v2'
+param vmSize string = 'Standard_D2s_v3'
 param configureSitetosite bool = true
 param location string  = resourceGroup().location
 
 var nicNameWindowsName = 'nic-windows'
 var vmNameWindowsName = 'vm-windows'
-var windowsOSVersion = '2016-Datacenter'
+var windowsOSVersion = '2025-datacenter-smalldisk-g2'
 
 resource mocOnpremNetworkResource 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: mocOnpremNetwork.name
@@ -283,11 +283,6 @@ resource windowsVM 'Microsoft.Compute/virtualMachines@2024-11-01' = {
       adminPassword: adminPassword
       windowsConfiguration: {
         enableAutomaticUpdates: true
-        patchSettings: {
-          //Machines should be configured to periodically check for missing system updates
-          assessmentMode: 'AutomaticByPlatform'
-          patchMode: 'AutomaticByPlatform'
-        }
       }
     }
     storageProfile: {

--- a/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.json
@@ -38,7 +38,7 @@
         },
         "vmSize": {
             "type": "string",
-            "defaultValue": "Standard_DS1_v2"
+            "defaultValue": "Standard_D2s_v3"
         },
         "configureSitetosite": {
             "type": "bool",
@@ -51,7 +51,7 @@
     "variables": {
         "nicNameWindows": "nic-windows",
         "vmNameWindows": "vm-windows",
-        "windowsOSVersion": "2016-Datacenter"
+        "windowsOSVersion": "2025-datacenter-smalldisk-g2"
     },
     "resources": [
         {

--- a/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.json
@@ -327,7 +327,14 @@
                 "osProfile": {
                     "computerName": "[variables('vmNameWindows')]",
                     "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
+                    "adminPassword": "[parameters('adminPassword')]",
+                    "windowsConfiguration": {
+                        "enableAutomaticUpdates": true,
+                        "patchSettings": {
+                            "assessmentMode": "AutomaticByPlatform",
+                            "patchMode": "AutomaticByPlatform"
+                        }
+                    }
                 },
                 "storageProfile": {
                     "imageReference": {


### PR DESCRIPTION
## Why

Windows Server 2016/2022 reached end of mainstream support. Standard_A4_v2 is a legacy SKU with poor price-performance.

## What

- Update VM SKU from Standard_A4_v2 to Standard_D2s_v3 (all templates)
- Update OS images to Windows Server 2025 Gen2:
  - azure-network (VMSS web servers): `2025-datacenter-core-smalldisk-g2` (Core — no GUI needed)
  - mock-onprem (test VM): `2025-datacenter-smalldisk-g2` (full desktop for RDP/browser testing)
- Update README parameter tables with new vmSize default
- Retain patchSettings (AutomaticByPlatform) on mock-onprem VM

## Test

- [x] Bicep compiles without errors