### PR TITLE
patch (iac): [secure-hybrid-network] fix subnet sizing

### DIFF
--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
@@ -27,7 +27,7 @@ param vpnGateway object = {
 param bastionHost object = {
   name: 'AzureBastionHost'
   subnetName: 'AzureBastionSubnet'
-  subnetPrefix: '10.0.1.0/29'
+  subnetPrefix: '10.0.1.0/26'
   publicIPAddressName: 'pip-bastion'
   nsgName: 'nsg-hub-bastion'
 }

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
@@ -15,7 +15,7 @@ param spokeNetwork object = {
   name: 'vnet-spoke'
   addressPrefix: '10.100.0.0/16'
   subnetName: 'snet-spoke-resources'
-  subnetPrefix: '10.100.0.0/16'
+  subnetPrefix: '10.100.0.0/24'
   subnetNsgName: 'nsg-spoke-resources'
 }
 param vpnGateway object = {

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
@@ -37,7 +37,7 @@
                 "name": "vnet-spoke",
                 "addressPrefix": "10.100.0.0/16",
                 "subnetName": "snet-spoke-resources",
-                "subnetPrefix": "10.100.0.0/16",
+                "subnetPrefix": "10.100.0.0/24",
                 "subnetNsgName": "nsg-spoke-resources"
             }
         },

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
@@ -55,7 +55,7 @@
             "defaultValue": {
                 "name": "AzureBastionHost",
                 "subnetName": "AzureBastionSubnet",
-                "subnetPrefix": "10.0.1.0/29",
+                "subnetPrefix": "10.0.1.0/26",
                 "publicIPAddressName": "pip-bastion",
                 "nsgName": "nsg-hub-bastion"
             }

--- a/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.bicep
@@ -17,7 +17,7 @@ param mocOnpremGateway object = {
 param bastionHost object = {
   name: 'AzureBastionHost'
   subnetName: 'AzureBastionSubnet'
-  subnetPrefix: '192.168.254.0/27'
+  subnetPrefix: '192.168.254.0/26'
   publicIPAddressName: 'pip-bastion'
   nsgName: 'nsg-hub-bastion'
 }

--- a/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/mock-onprem-azuredeploy.json
@@ -31,7 +31,7 @@
             "defaultValue": {
                 "name": "AzureBastionHost",
                 "subnetName": "AzureBastionSubnet",
-                "subnetPrefix": "192.168.254.0/27",
+                "subnetPrefix": "192.168.254.0/26",
                 "publicIPAddressName": "pip-bastion",
                 "nsgName": "nsg-hub-bastion"
             }


### PR DESCRIPTION
## Why

Bastion subnet at /29 (8 IPs) fails deployment — Azure requires minimum /26 (64 IPs). Spoke subnet consuming the entire /16 VNet address space leaves no room for future subnets.

## What

- Fix Bastion subnet from /29 to /26
- Reduce spoke subnet from /16 to /24

## Test

- [x] Bicep compiles without errors
- [x] Bastion subnet meets Azure minimum /26 requirement

Replaces #265 (closed accidentally).