### PR TITLE
topic (iac): [secure-hybrid-network] tighten firewall application rules

### DIFF
--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.bicep
@@ -533,22 +533,12 @@ resource azureFirewallResource 'Microsoft.Network/azureFirewalls@2024-05-01' = {
           }
           rules: [
             {
-              name: 'all-internet'
-              protocols: [
-                {
-                  protocolType: 'Http'
-                  port: 80
-                }
-                {
-                  protocolType: 'Https'
-                  port: 443
-                }
-              ]
-              targetFqdns: [
-                '*'
+              name: 'windows-update'
+              fqdnTags: [
+                'WindowsUpdate'
               ]
               sourceAddresses: [
-                '*'
+                spokeNetwork.addressPrefix
               ]
             }
           ]

--- a/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
+++ b/solutions/secure-hybrid-network/nestedtemplates/azure-network-azuredeploy.json
@@ -628,22 +628,12 @@
                             },
                             "rules": [
                                 {
-                                    "name": "all-internet",
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Http",
-                                            "port": 80
-                                        },
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "*"
+                                    "name": "windows-update",
+                                    "fqdnTags": [
+                                        "WindowsUpdate"
                                     ],
                                     "sourceAddresses": [
-                                        "*"
+                                        "[parameters('spokeNetwork').addressPrefix]"
                                     ]
                                 }
                             ]


### PR DESCRIPTION
## Why

The firewall allows all outbound HTTP/HTTPS to any FQDN from any source — a reference implementation should demonstrate least-privilege.

## What

- Replace all-internet rule (HTTP/HTTPS to * from *) with windows-update rule using WindowsUpdate FQDN tag
- Limit source to spoke address prefix only

## Test

- [x] Bicep compiles without errors

Replaces #266 (closed accidentally).